### PR TITLE
Clarifying `if` statement formatting

### DIFF
--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -54,7 +54,8 @@ HandshakeResponse.fromPacket = function (packet)
     args.authToken = packet.readBuffer(authTokenLength);
   } else {
     args.authToken = packet.readNullTerminatedString(encoding);
-  } if (isSet('CONNECT_WITH_DB')) {
+  }
+  if (isSet('CONNECT_WITH_DB')) {
     args.database = packet.readNullTerminatedString(encoding);
   }
   if (isSet('PLUGIN_AUTH')) {


### PR DESCRIPTION
Currently the `if` block looks like it's part of the larger `if/else` block above it, but it's a separate declaration. Adding a newline makes it immediately clear that these are separate logical blocks to readers of the code.